### PR TITLE
should not return gzip buffer when accept encoding not include gzip

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,15 +90,21 @@ module.exports = function staticCache(dir, options, files) {
         if (this.method === 'HEAD')
           return
 
+        var acceptGzip = this.acceptsEncodings('gzip') === 'gzip';
+
         if (file.zipBuffer) {
-          this.set('Content-Encoding', 'gzip')
-          this.body = file.zipBuffer
+          if (acceptGzip) {
+            this.set('Content-Encoding', 'gzip')
+            this.body = file.zipBuffer
+          } else {
+            this.body = file.buffer
+          }
           return
         }
 
         var shouldGzip = enableGzip
           && file.length > 1024
-          && this.acceptsEncodings('gzip') === 'gzip'
+          && acceptGzip
           && compressible(file.type)
 
         if (file.buffer) {

--- a/test/index.js
+++ b/test/index.js
@@ -272,6 +272,29 @@ describe('Static Cache', function () {
     })
   })
 
+  it('should not serve files with gzip buffer when accept encoding not include gzip',
+  function (done) {
+    var index = fs.readFileSync('index.js')
+    request(server3)
+    .get('/index.js')
+    .set('Accept-Encoding', '')
+    .expect(200)
+    .expect('Cache-Control', 'public, max-age=0')
+    .expect('Content-Type', /javascript/)
+    .expect('Content-Length', index.length)
+    .expect('Vary', 'Accept-Encoding')
+    .expect(index.toString())
+    .end(function (err, res) {
+      if (err)
+        return done(err)
+      res.should.not.have.header('Content-Encoding')
+      res.should.have.header('Content-Length')
+      res.should.have.header('Last-Modified')
+      res.should.have.header('ETag')
+      done()
+    })
+  })
+
   it('should serve files with gzip stream', function (done) {
     var index = fs.readFileSync('index.js')
     zlib.gzip(index, function (err, content) {


### PR DESCRIPTION
return `file.buffer` instead of `file.zipBuffer` when accept encoding is not gzip.
