### PR TITLE
decodeURI when use this.path as key to fetch value from files object

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = function staticCache(dir, options, files) {
   }
 
   return function* staticCache(next) {
-    var file = files[decodeURI(this.path)]
+    var file = files[safeDecodeURIComponent(this.path)]
     if (!file)
       return yield* next
 
@@ -157,5 +157,13 @@ var stat = function (file) {
 function gzip(buf) {
   return function (done) {
     zlib.gzip(buf, done)
+  }
+}
+
+function safeDecodeURIComponent(text) {
+  try {
+    return decodeURIComponent(text);
+  } catch (e) {
+    return text;
   }
 }


### PR DESCRIPTION
The path of some resources are non-standard,may contains Chinese
characters or something else,these characters are encoded,
static_cache can't recgonize them well.
