### PR TITLE
Set basic CRUD to continue to middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,10 +60,6 @@ module.exports = function staticCache(dir, options, files) {
       return yield* next
 
     switch (this.method) {
-      case 'POST':
-      case 'PUT':
-      case 'DELETE':
-        return yield* next
       case 'HEAD':
       case 'GET':
         this.status = 200
@@ -145,9 +141,7 @@ module.exports = function staticCache(dir, options, files) {
         this.set('Allow', 'HEAD,GET,OPTIONS')
         return
       default:
-        this.status = 405
-        this.set('Allow', 'HEAD,GET,OPTIONS')
-        return
+        return yield* next
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -185,11 +185,11 @@ describe('Static Cache', function () {
     .expect('', done)
   })
 
-  it('should support 405 Method Not Allowed', function (done) {
+  it('should support 404 Not Found for other Methods to allow downstream', 
+  function (done) {
     request(server)
     .put('/index.js')
-    .expect('Allow', 'HEAD,GET,OPTIONS')
-    .expect(405, done)
+    .expect(404, done)
   })
 
   it('should ignore query strings', function (done) {


### PR DESCRIPTION
If you have your statics aliased to GET and your CRUD (POST, PUT, DELETE) on the same route this middleware will drop to default and throw a 405.

This simply adds yield when the CRUD methods are called. 
