### PR TITLE
fix problem, cache is not used in dynamic mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = function staticCache(dir, options, files) {
     if (!file) {
       if (!options.dynamic) return yield* next
       if (path.basename(filename)[0] === '.') return yield* next
+      if (filename.charAt(0) === path.sep) filename = filename.slice(1)
       try {
         var s = yield stat(path.join(dir, filename))
         if (!s.isFile()) return yield* next


### PR DESCRIPTION
Because,
During initialization key but "static/foo.png",
key in dynamic is to become a "/static/foo.png".
So file is loaded every time, dynamic cache is not used.