### PR TITLE
bugfix. pathname error in windows operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ function safeDecodeURIComponent(text) {
  */
 
 function loadFile(name, dir, options, files) {
-  var pathname = options.prefix + name
+  var pathname = path.normalize(path.join(options.prefix, name))
   var obj = files[pathname] = files[pathname] ? files[pathname] : {}
   var filename = obj.path = path.join(dir, name)
   var stats = fs.statSync(filename)


### PR DESCRIPTION
the 'pathname' is incorrect when i set options like this:
```
app.use(staticCache(path.join(__dirname, 'public'), {
  prefix: '/static'
}))
```
this problem appears in Windows only, because `path.normalize()` change `/` into `\`.