### PR TITLE
bugfix: error on dynamic files

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,14 @@ module.exports = function staticCache(dir, options, files) {
       if (!options.dynamic) return yield* next
       if (path.basename(filename)[0] === '.') return yield* next
       if (filename.charAt(0) === path.sep) filename = filename.slice(1)
+
+      if (options.prefix !== path.sep) {
+        var prefix = path.normalize(options.prefix)
+        if (prefix.charAt(0) === path.sep) prefix = prefix.slice(1)
+        if (filename.indexOf(prefix) !== 0) return yield* next
+        filename = filename.slice(prefix.length)
+      }
+
       try {
         var s = yield stat(path.join(dir, filename))
         if (!s.isFile()) return yield* next

--- a/test/index.js
+++ b/test/index.js
@@ -367,6 +367,34 @@ describe('Static Cache', function () {
       })
   })
 
+  it('should work fine when new file added in dynamic and prefix mode', function (done) {
+    var app = koa()
+    app.use(staticCache({dynamic: true, prefix: '/static'}))
+    var server = app.listen()
+    fs.writeFileSync('a.js', 'hello world');
+
+    request(server)
+      .get('/static/a.js')
+      .expect(200, function(err) {
+        fs.unlinkSync('a.js')
+        done(err)
+      })
+  })
+
+  it('should 404 when url without prefix in dynamic and prefix mode', function (done) {
+    var app = koa()
+    app.use(staticCache({dynamic: true, prefix: '/static'}))
+    var server = app.listen()
+    fs.writeFileSync('a.js', 'hello world');
+
+    request(server)
+      .get('/a.js')
+      .expect(404, function(err) {
+        fs.unlinkSync('a.js')
+        done(err)
+      })
+  })
+
   it('should 404 when new hidden file added in dynamic mode', function (done) {
     var app = koa()
     app.use(staticCache({dynamic: true}))


### PR DESCRIPTION
fix the bug when the option is

    {
        dynamic: true,
        prefix: '/static'
    }

'/static/a.js' it doesn't work ( a.js is added after initialization ). 

it need remove the prefix to find the real filepath.
and when the option has prefix, the url '/a.js' shouldn't work

forgive me for my poor English. thanks:)
