### PR TITLE
fix: dynamic load file bug on windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function staticCache(dir, options, files) {
   files = files || options.files || Object.create(null)
   dir = dir || options.dir || process.cwd()
   var enableGzip = !!options.gzip
-  var filePrefix = path.normalize(options.prefix).replace(/^\//, '')
+  var filePrefix = path.normalize(options.prefix.replace(/^\//, ''))
 
   // option.filter
   var fileFilter = function () { return true }


### PR DESCRIPTION
there is a bug on windows, that failed to load file dynamically

config:
```js
options: {
  prefix: '/public/'
  ...
}
```

should remove first "/", then path.normalize
```js
//  right:   /public/ => public\
//  wrong:  /public/ => /public\
var filePrefix = path.normalize(options.prefix.replace(/^\//, ''))
```