### PR TITLE
update mz to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "*",
     "fs-readdir-recursive": "~1.0.0",
     "mime-types": "~2.1.8",
-    "mz": "~2.2.0"
+    "mz": "~2.4.0"
   },
   "devDependencies": {
     "bluebird": "3",


### PR DESCRIPTION
Hi, when installing `koa-static-cache` there is a warning:
```
npm WARN deprecated native-or-bluebird@1.2.0: 'native-or-bluebird' is deprecated. Please use 'any-promise' instead.
```

It's because of outdated `mz` package. mz@2.4.0 uses `any-promise`, so this annoying deprecation notice will go away. Thanks.