### PR TITLE
fix: only load file under options.dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,16 +69,19 @@ module.exports = function staticCache(dir, options, files) {
         filename = filename.slice(filePrefix.length)
       }
 
+      var fullpath = path.join(dir, filename)
+      // files that can be accessd should be under options.dir
+      if (fullpath.indexOf(path.normalize(dir)) !== 0) {
+        return yield next
+      }
+
       var s
       try {
-        var fullpath = path.join(dir, filename)
-        if (fullpath.indexOf(path.normalize(dir)) !== 0) {
-          return yield next
-        }
         s = yield fs.stat(fullpath);
       } catch (err) {
         return yield next
       }
+
       if (!s.isFile()) return yield next
 
       file = loadFile(filename, dir, options, files)

--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ module.exports = function staticCache(dir, options, files) {
 
       var s
       try {
-        s = yield fs.stat(path.join(dir, filename))
+        var fullpath = path.join(dir, filename)
+        if (fullpath.indexOf(dir) === -1) {
+          return yield next
+        }
+        s = yield fs.stat(fullpath);
       } catch (err) {
         return yield next
       }

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function staticCache(dir, options, files) {
       var s
       try {
         var fullpath = path.join(dir, filename)
-        if (fullpath.indexOf(dir) === -1) {
+        if (fullpath.indexOf(path.normalize(dir)) !== 0) {
           return yield next
         }
         s = yield fs.stat(fullpath);

--- a/index.js
+++ b/index.js
@@ -53,8 +53,7 @@ module.exports = function staticCache(dir, options, files) {
 
     // decode for `/%E4%B8%AD%E6%96%87`
     // normalize for `//index`
-    var filename = safeDecodeURIComponent(path.normalize(this.path))
-
+    var filename = path.normalize(safeDecodeURIComponent(this.path))
     var file = files.get(filename)
 
     // try to load file

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function staticCache(dir, options, files) {
   options.prefix = (options.prefix || '').replace(/\/*$/, '/')
   files = new FileManager(files || options.files)
   dir = dir || options.dir || process.cwd()
+  dir = path.normalize(dir);
   var enableGzip = !!options.gzip
   var filePrefix = path.normalize(options.prefix.replace(/^\//, ''))
 
@@ -70,7 +71,7 @@ module.exports = function staticCache(dir, options, files) {
 
       var fullpath = path.join(dir, filename)
       // files that can be accessd should be under options.dir
-      if (fullpath.indexOf(path.normalize(dir)) !== 0) {
+      if (fullpath.indexOf(dir) !== 0) {
         return yield next
       }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function staticCache(dir, options, files) {
   options.prefix = (options.prefix || '').replace(/\/*$/, '/')
   files = new FileManager(files || options.files)
   dir = dir || options.dir || process.cwd()
-  dir = path.normalize(dir);
+  dir = path.normalize(dir)
   var enableGzip = !!options.gzip
   var filePrefix = path.normalize(options.prefix.replace(/^\//, ''))
 
@@ -77,7 +77,7 @@ module.exports = function staticCache(dir, options, files) {
 
       var s
       try {
-        s = yield fs.stat(fullpath);
+        s = yield fs.stat(fullpath)
       } catch (err) {
         return yield next
       }

--- a/test/index.js
+++ b/test/index.js
@@ -528,13 +528,11 @@ describe('Static Cache', function () {
 
   it('should loadFile under options.dir', function (done) {
     var app = koa()
-    var files = {}
     app.use(staticCache({
       dir: __dirname,
       preload: false,
       dynamic: true,
     }))
-    files.should.eql({})
     request(app.listen())
       .get('/%2E%2E/package.json')
       .expect(404)

--- a/test/index.js
+++ b/test/index.js
@@ -536,6 +536,6 @@ describe('Static Cache', function () {
     request(app.listen())
       .get('/%2E%2E/package.json')
       .expect(404)
-      .end(done);
+      .end(done)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -525,4 +525,19 @@ describe('Static Cache', function () {
         done()
       })
   })
+
+  it('should loadFile under options.dir', function (done) {
+    var app = koa()
+    var files = {}
+    app.use(staticCache({
+      dir: __dirname,
+      preload: false,
+      dynamic: true,
+    }))
+    files.should.eql({})
+    request(app.listen())
+      .get('/%2E%2E/package.json')
+      .expect(404)
+      .end(done);
+  })
 })


### PR DESCRIPTION
THIS IS A SECURITY ISSUE

If request static file with percentage encode When dynamic,
it only join the path without checking whether it's based on options.dir,
so it will load any file from ths disk.