### PR TITLE
Update package.json bump debug and mz versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
   },
   "dependencies": {
     "compressible": "~2.0.6",
-    "debug": "3.1.0",
+    "debug": "^3.1.0",
     "fs-readdir-recursive": "~1.0.0",
     "mime-types": "~2.1.8",
-    "mz": "~2.7.0"
+    "mz": "^2.7.0"
   },
   "devDependencies": {
     "bluebird": "3",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
   },
   "dependencies": {
     "compressible": "~2.0.6",
-    "debug": "*",
+    "debug": "3.1.0",
     "fs-readdir-recursive": "~1.0.0",
     "mime-types": "~2.1.8",
-    "mz": "~2.6.0"
+    "mz": "~2.7.0"
   },
   "devDependencies": {
     "bluebird": "3",


### PR DESCRIPTION
Debug - 3.1.0 fixes:  https://github.com/visionmedia/debug/issues/501 
mz - most stable version is 2.7.0