### PR TITLE
fix: maxAge 0 does not work

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function loadFile(name, dir, options, files) {
   var buffer = fs.readFileSync(filename)
 
   obj.cacheControl = options.cacheControl
-  obj.maxAge = obj.maxAge ? obj.maxAge : options.maxAge || 0
+  obj.maxAge = (typeof obj.maxAge === 'number' ? obj.maxAge : options.maxAge) || 0
   obj.type = obj.mime = mime.lookup(pathname) || 'application/octet-stream'
   obj.mtime = stats.mtime
   obj.length = stats.size

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,9 @@ app5.use(staticCache({
 }))
 var server5 = http.createServer(app5.callback())
 
+var app6 = new Koa()
+var server6 = http.createServer(app6.callback())
+
 describe('Static Cache', function () {
 
   it('should dir priority than options.dir', function (done) {
@@ -210,6 +213,21 @@ describe('Static Cache', function () {
     request(server)
     .get('/package.json')
     .expect('Cache-Control', 'public, max-age=1')
+    .expect(200, done)
+  })
+
+  it('should set the maxAge 0', function (done) {
+    app6.use(staticCache(path.join(__dirname, '..'), {
+      maxAge: 365 * 24 * 60 * 60
+    }, {
+      '/package.json': {
+        maxAge: 0
+      }
+    }))
+
+    request(server6)
+    .get('/package.json')
+    .expect('Cache-Control', 'public, max-age=0')
     .expect(200, done)
   })
 


### PR DESCRIPTION
```js
{
        gzip: true,
        maxAge: 365 * 24 * 60 * 60,
        usePrecompiledGzip: true
      },
      {
        '/index.html': {
          maxAge: 0
      }
}
```

I set `maxAge = 0` for `index.html`, but I got `365 * 24 * 60 * 60`.
because `obj.maxAge ? xx:xx`  for 0 is `false`,so I got options.maxAge