### PR TITLE
Remove obsolete http header content-md5

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ module.exports = function staticCache(dir, options, files) {
     ctx.type = file.type
     ctx.length = file.zipBuffer ? file.zipBuffer.length : file.length
     ctx.set('cache-control', file.cacheControl || 'public, max-age=' + file.maxAge)
-    if (file.md5) ctx.set('content-md5', file.md5)
 
     if (ctx.method === 'HEAD')
       return

--- a/test/index.js
+++ b/test/index.js
@@ -213,14 +213,13 @@ describe('Static Cache', function () {
     .expect(200, done)
   })
 
-  it('should set the etag and content-md5 headers', function (done) {
+  it('should set the etag header', function (done) {
     var pk = fs.readFileSync('package.json')
     var md5 = crypto.createHash('md5').update(pk).digest('base64')
 
     request(server)
     .get('/package.json')
     .expect('ETag', '"' + md5 + '"')
-    .expect('Content-MD5', md5)
     .expect(200, done)
   })
 


### PR DESCRIPTION
The HTTP header content-md5 is obsolete and shouldn't be used.
Reference:
```
The Content-MD5 header field has been removed because it was
inconsistently implemented with respect to partial responses.
```
https://tools.ietf.org/html/rfc7231#appendix-B

This PR removes the header from source and tests.