### PR TITLE
fix: 修复在未开启 buffer 且静态文件回退的场景下，插件无法正确处理的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = function staticCache(dir, options, files) {
         file.md5 = hash.digest('base64')
       })
     }
-
+    ctx.response.etag = file.md5
     ctx.body = stream
     // enable gzip will remove content length
     if (shouldGzip) {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function staticCache(dir, options, files) {
 
     if (!file.buffer) {
       var stats = await fs.stat(file.path)
-      if (stats.mtime > file.mtime) {
+      if (stats.mtime + "" !== file.mtime + "") {
         file.mtime = stats.mtime
         file.md5 = null
         file.length = stats.size
@@ -93,7 +93,7 @@ module.exports = function staticCache(dir, options, files) {
     ctx.response.lastModified = file.mtime
     if (file.md5) ctx.response.etag = file.md5
 
-    if (ctx.fresh)
+    if (file.md5 && ctx.fresh)
       return ctx.status = 304
 
     ctx.type = file.type

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ module.exports = function staticCache(dir, options, files) {
     if (!file.buffer) {
       var stats = await fs.stat(file.path)
       if (stats.mtime + "" !== file.mtime + "") {
+        file.isPreVersion = stats.mtime > file.mtime ? false : true
         file.mtime = stats.mtime
         file.md5 = null
         file.length = stats.size
@@ -148,7 +149,7 @@ module.exports = function staticCache(dir, options, files) {
         file.md5 = hash.digest('base64')
       })
     }
-    ctx.response.etag = file.md5
+    file.isPreVersion && (ctx.response.etag = file.md5)
     ctx.body = stream
     // enable gzip will remove content length
     if (shouldGzip) {


### PR DESCRIPTION
Fixed the code logic when no buffer for file and had reset the file to previous version