### PR TITLE
Support Brotli

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ app.use(staticCache(path.join(__dirname, 'public'), {
 - `options.buffer` (bool) - store the files in memory instead of streaming from the filesystem on each request.
 - `options.gzip` (bool) - when request's accept-encoding include gzip, files will compressed by gzip.
 - `options.usePrecompiledGzip` (bool) - try use gzip files, loaded from disk, like nginx gzip_static
+- `options.brotli` (bool) - when request's accept-encoding include br, files will compressed by brotli.
+- `options.usePrecompiledBrotli` (bool) - try use brotli files, loaded from disk
 - `options.alias` (obj) - object map of aliases. See below.
 - `options.prefix` (str) - the url prefix you wish to add, default to `''`.
 - `options.dynamic` (bool) - dynamic load file which not cached on initialization.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha": "2",
     "should": "8",
     "should-http": "0.0.4",
-    "supertest": "1",
+    "supertest": "5",
     "ylru": "1"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,26 @@ app5.use(staticCache({
 }))
 var server5 = http.createServer(app5.callback())
 
+var app6 = new Koa()
+app6.use(staticCache(path.join(__dirname, '..'), {
+  buffer: true,
+  brotli: true,
+  filter(file) {
+    return !file.includes('node_modules')
+  }
+}))
+var server6 = http.createServer(app6.callback())
+
+var app7 = new Koa()
+var files7 = {}
+app7.use(staticCache(path.join(__dirname, '..'), {
+  brotli: true,
+  filter(file) {
+    return !file.includes('node_modules')
+  }
+}, files7))
+var server7 = http.createServer(app7.callback())
+
 describe('Static Cache', function () {
 
   it('should dir priority than options.dir', function (done) {
@@ -600,5 +620,86 @@ describe('Static Cache', function () {
       .get('/%2E%2E/package.json')
       .expect(404)
       .end(done)
+  })
+
+  it('should serve files with brotli buffer', function (done) {
+    var index = fs.readFileSync('index.js')
+    zlib.brotliCompress(index, function (err, content) {
+      request(server6)
+      .get('/index.js')
+      .set('Accept-Encoding', 'br')
+      .responseType('arraybuffer')
+      .expect(200)
+      .expect('Cache-Control', 'public, max-age=0')
+      .expect('Content-Encoding', 'br')
+      .expect('Content-Type', /javascript/)
+      .expect('Content-Length', String(content.length))
+      .expect('Vary', 'Accept-Encoding')
+      .expect(function (res) {
+        return res.body.toString('hex') === content.toString('hex')
+      })
+      .end(function (err, res) {
+        if (err)
+          return done(err)
+        res.should.have.header('Content-Length')
+        res.should.have.header('Last-Modified')
+        res.should.have.header('ETag')
+
+        etag = res.headers.etag
+
+        done()
+      })
+    })
+  })
+
+  it('should not serve files with brotli buffer when accept encoding not include br',
+  function (done) {
+    var index = fs.readFileSync('index.js')
+    request(server6)
+    .get('/index.js')
+    .set('Accept-Encoding', '')
+    .expect(200)
+    .expect('Cache-Control', 'public, max-age=0')
+    .expect('Content-Type', /javascript/)
+    .expect('Content-Length', String(index.length))
+    .expect('Vary', 'Accept-Encoding')
+    .expect(index.toString())
+    .end(function (err, res) {
+      if (err)
+        return done(err)
+      res.should.not.have.header('Content-Encoding')
+      res.should.have.header('Content-Length')
+      res.should.have.header('Last-Modified')
+      res.should.have.header('ETag')
+      done()
+    })
+  })
+
+  it('should serve files with brotli stream', function (done) {
+    var index = fs.readFileSync('index.js')
+    zlib.brotliCompress(index, function (err, content) {
+      request(server7)
+      .get('/index.js')
+      .set('Accept-Encoding', 'br')
+      .expect(200)
+      .expect('Cache-Control', 'public, max-age=0')
+      .expect('Content-Encoding', 'br')
+      .expect('Content-Type', /javascript/)
+      .expect('Vary', 'Accept-Encoding')
+      .expect(function (res) {
+        return res.body.toString('hex') === content.toString('hex')
+      })
+      .end(function (err, res) {
+        if (err)
+          return done(err)
+        res.should.not.have.header('Content-Length')
+        res.should.have.header('Last-Modified')
+        res.should.have.header('ETag')
+
+        etag = res.headers.etag
+
+        done()
+      })
+    })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -189,7 +189,7 @@ describe('Static Cache', function () {
     request(server)
     .head('/index.js')
     .expect(200)
-    .expect('', done)
+    .expect(undefined, done)
   })
 
   it('should support 404 Not Found for other Methods to allow downstream',
@@ -284,7 +284,7 @@ describe('Static Cache', function () {
       .expect('Cache-Control', 'public, max-age=0')
       .expect('Content-Encoding', 'gzip')
       .expect('Content-Type', /javascript/)
-      .expect('Content-Length', content.length)
+      .expect('Content-Length', String(content.length))
       .expect('Vary', 'Accept-Encoding')
       .expect(index.toString())
       .end(function (err, res) {
@@ -310,7 +310,7 @@ describe('Static Cache', function () {
     .expect(200)
     .expect('Cache-Control', 'public, max-age=0')
     .expect('Content-Type', /javascript/)
-    .expect('Content-Length', index.length)
+    .expect('Content-Length', String(index.length))
     .expect('Vary', 'Accept-Encoding')
     .expect(index.toString())
     .end(function (err, res) {


### PR DESCRIPTION
This pull requests adds the support for Brotli, both of dynamic compression and precompiled `.br` files.
It's a missing piece that `koa-static` does have.

I've also updated `supertest` to the latest version as I needed `.responseType('arraybuffer')` in the test cases.

Closes #77