### PR TITLE
Support configured charsets for static content

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ app.use(staticCache(path.join(__dirname, 'public'), {
 - `options.maxAge` (int) - cache control max age for the files, `0` by default.
 - `options.cacheControl` (str) - optional cache control header. Overrides `options.maxAge`.
 - `options.buffer` (bool) - store the files in memory instead of streaming from the filesystem on each request.
-- `options.gzip` (bool) - when request's accept-encoding include gzip, files will compressed by gzip.
-- `options.charset` (str | function) - optional charset appended to `Content-Type`. If a function is supplied, it receives `(file, type)` and can return a charset per file.
-- `options.usePrecompiledGzip` (bool) - try use gzip files, loaded from disk, like nginx gzip_static
+- `options.gzip` (bool) - when the request's Accept-Encoding includes gzip, files will be compressed using gzip.
+- `options.charset` (str | function) - optional charset appended to `Content-Type`. If a function is supplied, it receives `(file, type)`, where `file` is the relative file path, and can return a charset per file.
+- `options.usePrecompiledGzip` (bool) - try to use gzip files, loaded from disk, like nginx gzip_static
 - `options.alias` (obj) - object map of aliases. See below.
-- `options.prefix` (str) - the url prefix you wish to add, default to `''`.
+- `options.prefix` (str) - the URL prefix you wish to add, defaults to `''`.
 - `options.dynamic` (bool) - dynamic load file which not cached on initialization.
 - `options.filter` (function | array) - filter files at init dir, for example - skip non build (source) files. If array set - allow only listed files
 - `options.preload` (bool) - caches the assets on initialization or not, default to `true`. always work together with `options.dynamic`.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ app.use(staticCache(path.join(__dirname, 'public'), {
 - `options.cacheControl` (str) - optional cache control header. Overrides `options.maxAge`.
 - `options.buffer` (bool) - store the files in memory instead of streaming from the filesystem on each request.
 - `options.gzip` (bool) - when request's accept-encoding include gzip, files will compressed by gzip.
+- `options.charset` (str | function) - optional charset appended to `Content-Type`. If a function is supplied, it receives `(file, type)` and can return a charset per file.
 - `options.usePrecompiledGzip` (bool) - try use gzip files, loaded from disk, like nginx gzip_static
 - `options.alias` (obj) - object map of aliases. See below.
 - `options.prefix` (str) - the url prefix you wish to add, default to `''`.

--- a/index.js
+++ b/index.js
@@ -186,7 +186,13 @@ function loadFile(name, dir, options, files) {
 
   obj.cacheControl = options.cacheControl
   obj.maxAge = (typeof obj.maxAge === 'number' ? obj.maxAge : options.maxAge) || 0
-  obj.type = obj.mime = mime.lookup(pathname) || 'application/octet-stream'
+  var type = mime.lookup(pathname) || 'application/octet-stream'
+  var charset = typeof options.charset === 'function'
+    ? options.charset(name, type)
+    : options.charset
+  obj.type = obj.mime = charset
+    ? type + '; charset=' + charset
+    : type
   obj.mtime = stats.mtime
   obj.length = stats.size
   obj.md5 = crypto.createHash('md5').update(buffer).digest('base64')

--- a/index.js
+++ b/index.js
@@ -190,7 +190,8 @@ function loadFile(name, dir, options, files) {
   var charset = typeof options.charset === 'function'
     ? options.charset(name, type)
     : options.charset
-  obj.type = obj.mime = charset
+  obj.mime = type
+  obj.type = charset
     ? type + '; charset=' + charset
     : type
   obj.mtime = stats.mtime

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,42 @@ describe('Static Cache', function () {
     })
   })
 
+  it('should serve files with configured charset', function (done) {
+    var app = new Koa()
+    app.use(staticCache(path.join(__dirname, '..'), {
+      charset: 'iso-8859-1',
+      filter(file) {
+        return file === 'README.md'
+      }
+    }))
+    var server = app.listen()
+
+    request(server)
+    .get('/README.md')
+    .expect('Content-Type', 'text/markdown; charset=iso-8859-1')
+    .expect(200, done)
+  })
+
+  it('should serve files with function configured charset', function (done) {
+    var app = new Koa()
+    app.use(staticCache(path.join(__dirname, '..'), {
+      charset(file, type) {
+        return file === 'README.md' && type === 'text/markdown'
+          ? 'windows-1252'
+          : undefined
+      },
+      filter(file) {
+        return file === 'README.md'
+      }
+    }))
+    var server = app.listen()
+
+    request(server)
+    .get('/README.md')
+    .expect('Content-Type', 'text/markdown; charset=windows-1252')
+    .expect(200, done)
+  })
+
   it('should serve recursive files', function (done) {
     request(server)
     .get('/test/index.js')

--- a/test/index.js
+++ b/test/index.js
@@ -166,6 +166,22 @@ describe('Static Cache', function () {
     .expect(200, done)
   })
 
+  it('should serve files with configured charset for unknown mime types', function (done) {
+    var app = new Koa()
+    app.use(staticCache(path.join(__dirname, '..'), {
+      charset: 'iso-8859-1',
+      filter(file) {
+        return file === 'Makefile'
+      }
+    }))
+    var server = app.listen()
+
+    request(server)
+    .get('/Makefile')
+    .expect('Content-Type', 'application/octet-stream; charset=iso-8859-1')
+    .expect(200, done)
+  })
+
   it('should serve files with function configured charset', function (done) {
     var app = new Koa()
     app.use(staticCache(path.join(__dirname, '..'), {
@@ -183,6 +199,24 @@ describe('Static Cache', function () {
     request(server)
     .get('/README.md')
     .expect('Content-Type', 'text/markdown; charset=windows-1252')
+    .expect(200, done)
+  })
+
+  it('should not append charset when charset function returns undefined', function (done) {
+    var app = new Koa()
+    app.use(staticCache(path.join(__dirname, '..'), {
+      charset() {
+        return undefined
+      },
+      filter(file) {
+        return file === 'Makefile'
+      }
+    }))
+    var server = app.listen()
+
+    request(server)
+    .get('/Makefile')
+    .expect('Content-Type', 'application/octet-stream')
     .expect(200, done)
   })
 


### PR DESCRIPTION
Closes #83.

This adds an optional `charset` setting for static file responses so applications that know their file encoding can return an explicit `Content-Type` charset instead of relying on Koa's default behavior.

What changed:
- add `options.charset` support as either a string or a `(file, type)` function
- preserve the existing MIME lookup fallback behavior
- document the new option in the README
- add regression coverage for string and function charset configuration

I kept this configurable rather than attempting automatic charset detection because the middleware does not have reliable encoding metadata for arbitrary static files.

Verification:
- `npm test`
- `git diff --check`

## Summary by Sourcery

Add optional charset configuration for static file responses and document and test the new behavior.

New Features:
- Allow configuring a static file response charset via an options.charset string or function.

Documentation:
- Document the new options.charset setting and its behavior in the README.

Tests:
- Add regression tests covering charset configuration as a fixed string and as a function.