### PR TITLE
fix: stream files too large to read unbuffered

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,14 +182,19 @@ function loadFile(name, dir, options, files) {
   var obj = files.get(pathname)
   var filename = obj.path = path.join(dir, name)
   var stats = fs.statSync(filename)
-  var buffer = fs.readFileSync(filename)
+  var buffer = null
+  try {
+    buffer = fs.readFileSync(filename)
+  } catch (err) {
+    if (options.buffer || err.code !== 'ERR_FS_FILE_TOO_LARGE') throw err
+  }
 
   obj.cacheControl = options.cacheControl
   obj.maxAge = (typeof obj.maxAge === 'number' ? obj.maxAge : options.maxAge) || 0
   obj.type = obj.mime = mime.lookup(pathname) || 'application/octet-stream'
   obj.mtime = stats.mtime
   obj.length = stats.size
-  obj.md5 = crypto.createHash('md5').update(buffer).digest('base64')
+  obj.md5 = buffer && crypto.createHash('md5').update(buffer).digest('base64')
 
   debug('file: ' + JSON.stringify(obj, null, 2))
   if (options.buffer)

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 var fs = require('fs')
+var mzfs = require('mz/fs')
 var crypto = require('crypto')
 var zlib = require('zlib')
 var request = require('supertest')
 var should = require('should')
 var Koa = require('koa')
 var http = require('http')
+var os = require('os')
 var path = require('path')
 var staticCache = require('..')
 var LRU = require('ylru')
@@ -618,5 +620,46 @@ describe('Static Cache', function () {
       .get('/%2E%2E/package.json')
       .expect(404)
       .end(done)
+  })
+
+  it('should stream dynamic files when unbuffered read is too large', function (done) {
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-cache-'))
+    var filename = path.join(dir, 'large.bin')
+    var originalReadFileSync = mzfs.readFileSync
+    var app = new Koa()
+    var server
+
+    fs.writeFileSync(filename, 'large file')
+    mzfs.readFileSync = function (file) {
+      if (file === filename) {
+        var err = new RangeError('File size is greater than 2 GiB')
+        err.code = 'ERR_FS_FILE_TOO_LARGE'
+        throw err
+      }
+      return originalReadFileSync.apply(this, arguments)
+    }
+
+    function cleanup() {
+      mzfs.readFileSync = originalReadFileSync
+      if (server) server.close()
+      fs.unlinkSync(filename)
+      fs.rmdirSync(dir)
+    }
+
+    app.use(staticCache(dir, {
+      buffer: false,
+      dynamic: true,
+      preload: false
+    }))
+
+    server = app.listen()
+    request(server)
+      .get('/large.bin')
+      .expect(200)
+      .expect('large file')
+      .end(function (err) {
+        cleanup()
+        done(err)
+      })
   })
 })


### PR DESCRIPTION
Closes #103.

When `fs.readFileSync()` reports `ERR_FS_FILE_TOO_LARGE`, unbuffered mode should still be able to serve the file through the existing stream path instead of crashing while trying to compute the eager MD5.

This preserves the current eager hash behavior for ordinary files, rethrows other read failures, and still rethrows the too-large error when `options.buffer` is enabled because that mode requires the file in memory.

Verification:
- `./node_modules/.bin/mocha --grep 'unbuffered read is too large'`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Handle large files in unbuffered mode without crashing by falling back to streaming when eager reads exceed size limits.

Bug Fixes:
- Avoid crashes when fs.readFileSync throws ERR_FS_FILE_TOO_LARGE in unbuffered, dynamic mode by skipping eager buffering and MD5 computation.

Tests:
- Add a regression test to ensure dynamic unbuffered responses stream correctly when readFileSync reports files as too large.