### PR TITLE
fix: use precompiled gzip when streaming files

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,17 @@ module.exports = function staticCache(dir, options, files) {
       return
     }
 
+    var precompiledGzip = shouldGzip && options.usePrecompiledGzip
+      ? await getPrecompiledGzip(file, filename, files)
+      : null
+
+    if (precompiledGzip) {
+      ctx.set('content-encoding', 'gzip')
+      ctx.length = precompiledGzip.length
+      ctx.body = precompiledGzip.buffer || fs.createReadStream(precompiledGzip.path)
+      return
+    }
+
     var stream = fs.createReadStream(file.path)
 
     // update file hash
@@ -154,6 +165,26 @@ module.exports = function staticCache(dir, options, files) {
       ctx.set('content-encoding', 'gzip')
       ctx.body = stream.pipe(zlib.createGzip())
     }
+  }
+}
+
+async function getPrecompiledGzip(file, filename, files) {
+  var gzFile = files.get(filename + '.gz')
+  if (gzFile) return gzFile
+
+  var gzPath = file.path + '.gz'
+  var stats
+  try {
+    stats = await fs.stat(gzPath)
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return null
+    throw err
+  }
+
+  if (!stats.isFile()) return null
+  return {
+    path: gzPath,
+    length: stats.size
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -182,6 +182,8 @@ async function getPrecompiledGzip(file, filename, files) {
   }
 
   if (!stats.isFile()) return null
+  if (stats.mtime.getTime() < file.mtime.getTime()) return null
+
   return {
     path: gzPath,
     length: stats.size

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 var fs = require('fs')
 var crypto = require('crypto')
 var zlib = require('zlib')
+var mzzlib = require('mz/zlib')
 var request = require('supertest')
 var should = require('should')
 var Koa = require('koa')
 var http = require('http')
+var os = require('os')
 var path = require('path')
 var staticCache = require('..')
 var LRU = require('ylru')
@@ -365,6 +367,53 @@ describe('Static Cache', function () {
 
         done()
       })
+    })
+  })
+
+  it('should serve precompiled gzip when streaming dynamic files', function (done) {
+    var app = new Koa()
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-cache-'))
+    var filename = path.join(dir, 'asset.js')
+    var gzFilename = filename + '.gz'
+    var content = Buffer.alloc(2048, 'a')
+    var gzContent = zlib.gzipSync(content)
+    var originalCreateGzip = mzzlib.createGzip
+    var server
+
+    fs.writeFileSync(filename, content)
+    fs.writeFileSync(gzFilename, gzContent)
+
+    mzzlib.createGzip = function () {
+      throw new Error('dynamic gzip should not be used')
+    }
+
+    function cleanup() {
+      mzzlib.createGzip = originalCreateGzip
+      if (server) server.close()
+      fs.unlinkSync(gzFilename)
+      fs.unlinkSync(filename)
+      fs.rmdirSync(dir)
+    }
+
+    app.use(staticCache(dir, {
+      buffer: false,
+      dynamic: true,
+      preload: false,
+      gzip: true,
+      usePrecompiledGzip: true
+    }))
+
+    server = app.listen()
+    request(server)
+    .get('/asset.js')
+    .set('Accept-Encoding', 'gzip')
+    .expect(200)
+    .expect('Content-Encoding', 'gzip')
+    .expect('Content-Length', String(gzContent.length))
+    .expect(content.toString())
+    .end(function (err) {
+      cleanup()
+      done(err)
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -382,6 +382,7 @@ describe('Static Cache', function () {
 
     fs.writeFileSync(filename, content)
     fs.writeFileSync(gzFilename, gzContent)
+    fs.utimesSync(gzFilename, new Date(), new Date(Date.now() + 1000))
 
     mzzlib.createGzip = function () {
       throw new Error('dynamic gzip should not be used')
@@ -390,9 +391,9 @@ describe('Static Cache', function () {
     function cleanup() {
       mzzlib.createGzip = originalCreateGzip
       if (server) server.close()
-      fs.unlinkSync(gzFilename)
-      fs.unlinkSync(filename)
-      fs.rmdirSync(dir)
+      try { fs.unlinkSync(gzFilename) } catch (err) {}
+      try { fs.unlinkSync(filename) } catch (err) {}
+      try { fs.rmdirSync(dir) } catch (err) {}
     }
 
     app.use(staticCache(dir, {
@@ -410,6 +411,48 @@ describe('Static Cache', function () {
     .expect(200)
     .expect('Content-Encoding', 'gzip')
     .expect('Content-Length', String(gzContent.length))
+    .expect(content.toString())
+    .end(function (err) {
+      cleanup()
+      done(err)
+    })
+  })
+
+  it('should ignore stale precompiled gzip when streaming dynamic files', function (done) {
+    var app = new Koa()
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-cache-'))
+    var filename = path.join(dir, 'asset.js')
+    var gzFilename = filename + '.gz'
+    var content = Buffer.alloc(2048, 'a')
+    var gzContent = zlib.gzipSync(Buffer.alloc(2048, 'b'))
+    var server
+
+    fs.writeFileSync(filename, content)
+    fs.writeFileSync(gzFilename, gzContent)
+    fs.utimesSync(filename, new Date(), new Date(Date.now() + 1000))
+    fs.utimesSync(gzFilename, new Date(), new Date())
+
+    function cleanup() {
+      if (server) server.close()
+      try { fs.unlinkSync(gzFilename) } catch (err) {}
+      try { fs.unlinkSync(filename) } catch (err) {}
+      try { fs.rmdirSync(dir) } catch (err) {}
+    }
+
+    app.use(staticCache(dir, {
+      buffer: false,
+      dynamic: true,
+      preload: false,
+      gzip: true,
+      usePrecompiledGzip: true
+    }))
+
+    server = app.listen()
+    request(server)
+    .get('/asset.js')
+    .set('Accept-Encoding', 'gzip')
+    .expect(200)
+    .expect('Content-Encoding', 'gzip')
     .expect(content.toString())
     .end(function (err) {
       cleanup()


### PR DESCRIPTION
Closes #100.

`usePrecompiledGzip` previously only used the cached `.gz` file when the original response was buffered. With `buffer: false`, the middleware streamed the original file and dynamically piped it through gzip even when an adjacent precompiled `.gz` file existed.

This keeps the existing gzip eligibility checks, preserves buffered behavior, and adds a streaming path for the precompiled gzip file.

Verification:
- `./node_modules/.bin/mocha --grep 'precompiled gzip when streaming dynamic files'`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Serve precompiled gzip assets when streaming static files with gzip enabled.

New Features:
- Add support for serving precompiled gzip files when static content is streamed instead of buffered.

Bug Fixes:
- Ensure middleware uses existing precompiled gzip files instead of dynamically gzipping when streaming responses with usePrecompiledGzip enabled.

Tests:
- Add regression test to verify precompiled gzip is used and dynamic gzip is not invoked when streaming dynamic files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static file handler now supports serving precompiled gzip-compressed assets, with automatic fallback to on-the-fly compression when precompiled versions are unavailable.

* **Tests**
  * Added test coverage for precompiled gzip asset serving with streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->