### PR TITLE
fix: avoid partial cache entries when file loading fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,12 +178,12 @@ function safeDecodeURIComponent(text) {
 
 function loadFile(name, dir, options, files) {
   var pathname = path.normalize(path.join(options.prefix, name))
-  if (!files.get(pathname)) files.set(pathname, {})
-  var obj = files.get(pathname)
-  var filename = obj.path = path.join(dir, name)
+  var obj = files.get(pathname) || {}
+  var filename = path.join(dir, name)
   var stats = fs.statSync(filename)
   var buffer = fs.readFileSync(filename)
 
+  obj.path = filename
   obj.cacheControl = options.cacheControl
   obj.maxAge = (typeof obj.maxAge === 'number' ? obj.maxAge : options.maxAge) || 0
   obj.type = obj.mime = mime.lookup(pathname) || 'application/octet-stream'
@@ -195,6 +195,7 @@ function loadFile(name, dir, options, files) {
   if (options.buffer)
     obj.buffer = buffer
 
+  files.set(pathname, obj)
   buffer = null
   return obj
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-var mzfs = require('mz/fs')
+var staticFs = require('mz/fs')
 var crypto = require('crypto')
 var zlib = require('zlib')
 var request = require('supertest')
@@ -423,14 +423,14 @@ describe('Static Cache', function () {
     var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-cache-'))
     var filename = path.join(dir, 'asset.txt')
     var files = {}
-    var originalReadFileSync = mzfs.readFileSync
+    var originalReadFileSync = staticFs.readFileSync
     var shouldFail = true
     var server
 
     app.silent = true
     fs.writeFileSync(filename, 'hello world')
 
-    mzfs.readFileSync = function (file) {
+    staticFs.readFileSync = function (file) {
       if (file === filename && shouldFail) {
         shouldFail = false
         throw new Error('read failed')
@@ -440,10 +440,10 @@ describe('Static Cache', function () {
     }
 
     function cleanup() {
-      mzfs.readFileSync = originalReadFileSync
+      staticFs.readFileSync = originalReadFileSync
       if (server) server.close()
-      fs.unlinkSync(filename)
-      fs.rmdirSync(dir)
+      try { fs.unlinkSync(filename) } catch (err) {}
+      try { fs.rmdirSync(dir) } catch (err) {}
     }
 
     app.use(staticCache(dir, {

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 var fs = require('fs')
+var mzfs = require('mz/fs')
 var crypto = require('crypto')
 var zlib = require('zlib')
 var request = require('supertest')
 var should = require('should')
 var Koa = require('koa')
 var http = require('http')
+var os = require('os')
 var path = require('path')
 var staticCache = require('..')
 var LRU = require('ylru')
@@ -413,6 +415,62 @@ describe('Static Cache', function () {
       .expect(200, function(err) {
         fs.unlinkSync('a.js')
         done(err)
+      })
+  })
+
+  it('should not cache partial file data when dynamic load fails', function (done) {
+    var app = new Koa()
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'static-cache-'))
+    var filename = path.join(dir, 'asset.txt')
+    var files = {}
+    var originalReadFileSync = mzfs.readFileSync
+    var shouldFail = true
+    var server
+
+    app.silent = true
+    fs.writeFileSync(filename, 'hello world')
+
+    mzfs.readFileSync = function (file) {
+      if (file === filename && shouldFail) {
+        shouldFail = false
+        throw new Error('read failed')
+      }
+
+      return originalReadFileSync.apply(this, arguments)
+    }
+
+    function cleanup() {
+      mzfs.readFileSync = originalReadFileSync
+      if (server) server.close()
+      fs.unlinkSync(filename)
+      fs.rmdirSync(dir)
+    }
+
+    app.use(staticCache(dir, {
+      dynamic: true,
+      preload: false,
+      files: files
+    }))
+
+    server = app.listen()
+    request(server)
+      .get('/asset.txt')
+      .expect(500, function (err) {
+        if (err) {
+          cleanup()
+          return done(err)
+        }
+
+        should.not.exist(files['/asset.txt'])
+
+        request(server)
+          .get('/asset.txt')
+          .expect(200)
+          .expect('hello world')
+          .end(function (err) {
+            cleanup()
+            done(err)
+          })
       })
   })
 


### PR DESCRIPTION
Closes #99.

`loadFile()` previously inserted an empty cache entry before `statSync()` and `readFileSync()` completed. If the read failed, the cache could retain a partial object with `path` but no `mtime`, letting a later request crash at `file.mtime.getTime()`.

This builds the metadata first and only publishes the cache entry after the file has been read and hashed successfully, while preserving existing per-file metadata such as `maxAge`.

Verification:
- `./node_modules/.bin/mocha --grep 'partial file data'`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Ensure static file cache entries are only created after files are successfully loaded to avoid partial metadata in the cache.

Bug Fixes:
- Prevent caching of partial file metadata when dynamic file loading fails, avoiding crashes on subsequent requests.

Tests:
- Add a regression test that simulates a read failure and verifies no partial cache entry is stored and that a subsequent successful read is served correctly.