### PR TITLE
Add custom response header hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ app.use(staticCache(path.join(__dirname, 'public'), {
 - `options.buffer` (bool) - store the files in memory instead of streaming from the filesystem on each request.
 - `options.gzip` (bool) - when request's accept-encoding include gzip, files will compressed by gzip.
 - `options.usePrecompiledGzip` (bool) - try use gzip files, loaded from disk, like nginx gzip_static
+- `options.setHeaders` (function) - optional `function (ctx, file)` hook to set custom response headers for matched files.
 - `options.alias` (obj) - object map of aliases. See below.
 - `options.prefix` (str) - the url prefix you wish to add, default to `''`.
 - `options.dynamic` (bool) - dynamic load file which not cached on initialization.

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = function staticCache(dir, options, files) {
 
     ctx.response.lastModified = file.mtime
     if (file.md5) ctx.response.etag = file.md5
+    if (setHeaders) setHeaders(ctx, file)
 
     if (ctx.fresh) return ctx.status = 304
 
@@ -102,7 +103,6 @@ module.exports = function staticCache(dir, options, files) {
     ctx.length = file.zipBuffer ? file.zipBuffer.length : file.length
     ctx.set('cache-control', file.cacheControl || 'public, max-age=' + file.maxAge)
     if (file.md5) ctx.set('content-md5', file.md5)
-    if (setHeaders) setHeaders(ctx, file)
 
     if (ctx.method === 'HEAD') return
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ module.exports = function staticCache(dir, options, files) {
   dir = path.normalize(dir)
   var enableGzip = !!options.gzip
   var filePrefix = path.normalize(options.prefix.replace(/^\//, ''))
+  var setHeaders = typeof options.setHeaders === 'function'
+    ? options.setHeaders
+    : null
 
   // option.filter
   var fileFilter = function () { return true }
@@ -99,6 +102,7 @@ module.exports = function staticCache(dir, options, files) {
     ctx.length = file.zipBuffer ? file.zipBuffer.length : file.length
     ctx.set('cache-control', file.cacheControl || 'public, max-age=' + file.maxAge)
     if (file.md5) ctx.set('content-md5', file.md5)
+    if (setHeaders) setHeaders(ctx, file)
 
     if (ctx.method === 'HEAD') return
 

--- a/test/index.js
+++ b/test/index.js
@@ -250,6 +250,59 @@ describe('Static Cache', function () {
     .expect(200, done)
   })
 
+  it('should set custom headers for streamed files', function (done) {
+    var app = new Koa()
+    var seenFile
+    app.use(staticCache(path.join(__dirname, '..'), {
+      setHeaders: function (ctx, file) {
+        seenFile = file
+        ctx.set('X-Static-Cache', file.type)
+      },
+      filter(file) {
+        return !file.includes('node_modules')
+      }
+    }))
+
+    request(app.listen())
+    .get('/index.js')
+    .expect('X-Static-Cache', /javascript/)
+    .expect(200, function (err) {
+      if (err)
+        return done(err)
+
+      seenFile.type.should.match(/javascript/)
+      seenFile.path.should.endWith('index.js')
+      done()
+    })
+  })
+
+  it('should set custom headers for buffered files', function (done) {
+    var app = new Koa()
+    var seenFile
+    app.use(staticCache(path.join(__dirname, '..'), {
+      buffer: true,
+      setHeaders: function (ctx, file) {
+        seenFile = file
+        ctx.set('X-Static-Length', String(file.length))
+      },
+      filter(file) {
+        return !file.includes('node_modules')
+      }
+    }))
+
+    request(app.listen())
+    .get('/index.js')
+    .expect('X-Static-Length', String(fs.statSync('index.js').size))
+    .expect(200, function (err) {
+      if (err)
+        return done(err)
+
+      should.exist(seenFile.buffer)
+      seenFile.path.should.endWith('index.js')
+      done()
+    })
+  })
+
   it('should set Last-Modified if file modified and not buffered', function (done) {
     setTimeout(function () {
       var readme = fs.readFileSync('README.md', 'utf8')

--- a/test/index.js
+++ b/test/index.js
@@ -303,6 +303,45 @@ describe('Static Cache', function () {
     })
   })
 
+  it('should set custom headers before returning 304 responses', function (done) {
+    var app = new Koa()
+    var seenFile
+    app.use(staticCache(path.join(__dirname, '..'), {
+      setHeaders: function (ctx, file) {
+        seenFile = file
+        ctx.set('X-Static-Cache', file.type)
+      },
+      filter(file) {
+        return file === 'index.js'
+      }
+    }))
+
+    var server = app.listen()
+
+    request(server)
+    .get('/index.js')
+    .expect('X-Static-Cache', /javascript/)
+    .expect(200, function (err, res) {
+      if (err) {
+        server.close()
+        return done(err)
+      }
+
+      request(server)
+      .get('/index.js')
+      .set('If-None-Match', res.headers.etag)
+      .expect('X-Static-Cache', /javascript/)
+      .expect(304, function (err) {
+        server.close()
+        if (err)
+          return done(err)
+
+        seenFile.type.should.match(/javascript/)
+        done()
+      })
+    })
+  })
+
   it('should set Last-Modified if file modified and not buffered', function (done) {
     setTimeout(function () {
       var readme = fs.readFileSync('README.md', 'utf8')


### PR DESCRIPTION
Closes #102.

This adds an optional `setHeaders(ctx, file)` hook that runs after the built-in static headers have been applied for a matched file. It lets applications add or override custom response headers while preserving the existing buffered, streamed, cache, and gzip behavior.

Verification:
- `./node_modules/.bin/mocha --grep "custom headers"`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Add a configurable hook to customize response headers for static file responses.

New Features:
- Introduce an optional options.setHeaders(ctx, file) hook to allow custom response headers on cached static file responses.

Documentation:
- Document the new options.setHeaders hook in the README with its purpose and signature.

Tests:
- Add tests verifying custom headers are applied for both streamed and buffered static file responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `setHeaders(ctx, file)` hook for `staticCache`, enabling custom response headers per matched cached file.
* **Documentation**
  * Updated the README API documentation to describe the new `setHeaders` option and its parameters.
* **Tests**
  * Added coverage to confirm `setHeaders` is invoked for both streamed and buffered responses, and that it also runs during conditional requests resulting in `304`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->