### PR TITLE
Refresh buffered files when source changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,12 +81,16 @@ module.exports = function staticCache(dir, options, files) {
 
     if (enableGzip) ctx.vary('Accept-Encoding')
 
-    if (!file.buffer) {
-      var stats = await fs.stat(file.path)
-      if (stats.mtime.getTime() !== file.mtime.getTime()) {
-        file.mtime = stats.mtime
-        file.md5 = null
-        file.length = stats.size
+    var stats = await fs.stat(file.path)
+    if (stats.mtime.getTime() !== file.mtime.getTime() || stats.size !== file.length) {
+      file.mtime = stats.mtime
+      file.md5 = null
+      file.length = stats.size
+      file.zipBuffer = null
+
+      if (file.buffer) {
+        file.buffer = await fs.readFile(file.path)
+        file.md5 = crypto.createHash('md5').update(file.buffer).digest('base64')
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -77,11 +77,14 @@ module.exports = function staticCache(dir, options, files) {
       file = loadFile(filename, dir, options, files)
     }
 
+    if (!await refreshFile(file)) {
+      files.set(filename, null)
+      return await next()
+    }
+
     ctx.status = 200
 
     if (enableGzip) ctx.vary('Accept-Encoding')
-
-    await refreshFile(file)
 
     ctx.response.lastModified = file.mtime
     if (file.md5) ctx.response.etag = file.md5
@@ -159,8 +162,15 @@ function safeDecodeURIComponent(text) {
 }
 
 async function refreshFile(file) {
-  var stats = await fs.stat(file.path)
-  if (stats.mtime.getTime() === file.mtime.getTime() && stats.size === file.length) return
+  var stats
+  try {
+    stats = await fs.stat(file.path)
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false
+    throw err
+  }
+
+  if (stats.mtime.getTime() === file.mtime.getTime() && stats.size === file.length) return true
 
   file.mtime = stats.mtime
   file.md5 = null
@@ -168,9 +178,16 @@ async function refreshFile(file) {
   file.zipBuffer = null
 
   if (file.buffer) {
-    file.buffer = await fs.readFile(file.path)
+    try {
+      file.buffer = await fs.readFile(file.path)
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return false
+      throw err
+    }
     file.md5 = crypto.createHash('md5').update(file.buffer).digest('base64')
   }
+
+  return true
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -81,18 +81,7 @@ module.exports = function staticCache(dir, options, files) {
 
     if (enableGzip) ctx.vary('Accept-Encoding')
 
-    var stats = await fs.stat(file.path)
-    if (stats.mtime.getTime() !== file.mtime.getTime() || stats.size !== file.length) {
-      file.mtime = stats.mtime
-      file.md5 = null
-      file.length = stats.size
-      file.zipBuffer = null
-
-      if (file.buffer) {
-        file.buffer = await fs.readFile(file.path)
-        file.md5 = crypto.createHash('md5').update(file.buffer).digest('base64')
-      }
-    }
+    await refreshFile(file)
 
     ctx.response.lastModified = file.mtime
     if (file.md5) ctx.response.etag = file.md5
@@ -166,6 +155,21 @@ function safeDecodeURIComponent(text) {
     return decodeURIComponent(text)
   } catch (e) {
     return text
+  }
+}
+
+async function refreshFile(file) {
+  var stats = await fs.stat(file.path)
+  if (stats.mtime.getTime() === file.mtime.getTime() && stats.size === file.length) return
+
+  file.mtime = stats.mtime
+  file.md5 = null
+  file.length = stats.size
+  file.zipBuffer = null
+
+  if (file.buffer) {
+    file.buffer = await fs.readFile(file.path)
+    file.md5 = crypto.createHash('md5').update(file.buffer).digest('base64')
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,83 @@ describe('Static Cache', function () {
     })
   })
 
+  it('should refresh buffered gzip cache when the source changes', function (done) {
+    var app = new Koa()
+    var files = {}
+    var filename = 'buffer-gzip-freshness.txt'
+    var before = new Array(2049).join('a')
+    var after = new Array(2049).join('b')
+
+    fs.writeFileSync(filename, before)
+    app.use(staticCache({
+      buffer: true,
+      dynamic: true,
+      gzip: true,
+      preload: false,
+      files: files
+    }))
+
+    request(app.listen())
+    .get('/' + filename)
+    .set('Accept-Encoding', 'gzip')
+    .expect('Content-Encoding', 'gzip')
+    .expect(200, before, function (err) {
+      if (err) {
+        fs.unlinkSync(filename)
+        return done(err)
+      }
+
+      var zipBuffer = files['/' + filename].zipBuffer
+      var future = new Date(Date.now() + 2000)
+      fs.writeFileSync(filename, after)
+      fs.utimesSync(filename, future, future)
+
+      request(app.listen())
+      .get('/' + filename)
+      .set('Accept-Encoding', 'gzip')
+      .expect('Content-Encoding', 'gzip')
+      .expect(200, after, function (err) {
+        fs.unlinkSync(filename)
+        if (err) return done(err)
+
+        Buffer.compare(files['/' + filename].zipBuffer, zipBuffer).should.not.equal(0)
+        done()
+      })
+    })
+  })
+
+  it('should fall through when a cached buffered file is removed', function (done) {
+    var app = new Koa()
+    var files = {}
+    var filename = 'buffer-removed.txt'
+
+    fs.writeFileSync(filename, 'cached')
+    app.use(staticCache({
+      buffer: true,
+      dynamic: true,
+      preload: false,
+      files: files
+    }))
+
+    request(app.listen())
+    .get('/' + filename)
+    .expect(200, 'cached', function (err) {
+      if (err) {
+        fs.unlinkSync(filename)
+        return done(err)
+      }
+
+      fs.unlinkSync(filename)
+
+      request(app.listen())
+      .get('/' + filename)
+      .expect(404, function (err) {
+        should(files['/' + filename]).equal(null)
+        done(err)
+      })
+    })
+  })
+
   it('should serve recursive files', function (done) {
     request(server)
     .get('/test/index.js')

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,45 @@ describe('Static Cache', function () {
     })
   })
 
+  it('should refresh buffered files when the source changes', function (done) {
+    var app = new Koa()
+    var files = {}
+    var filename = 'buffer-freshness.txt'
+
+    fs.writeFileSync(filename, 'before')
+    app.use(staticCache({
+      buffer: true,
+      dynamic: true,
+      preload: false,
+      files: files
+    }))
+
+    request(app.listen())
+    .get('/' + filename)
+    .expect(200, 'before', function (err, res) {
+      if (err) {
+        fs.unlinkSync(filename)
+        return done(err)
+      }
+
+      var etag = res.headers.etag
+      var future = new Date(Date.now() + 2000)
+      fs.writeFileSync(filename, 'after!')
+      fs.utimesSync(filename, future, future)
+
+      request(app.listen())
+      .get('/' + filename)
+      .expect(200, 'after!', function (err, res) {
+        fs.unlinkSync(filename)
+        if (err) return done(err)
+
+        files['/' + filename].buffer.toString().should.equal('after!')
+        res.headers.etag.should.not.equal(etag)
+        done()
+      })
+    })
+  })
+
   it('should serve recursive files', function (done) {
     request(server)
     .get('/test/index.js')


### PR DESCRIPTION
Closes #96.

Buffered files now use the same freshness check as streamed files. When the source file mtime or size changes, the cached metadata is refreshed; buffered responses also reload the file contents and recalculate the MD5/ETag before serving.

This also clears any cached gzip buffer when the source changes so compressed responses are regenerated from the current file contents.

Verification:
- `./node_modules/.bin/mocha --require should --require should-http --harmony --grep "refresh buffered files"`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Refresh cached static file metadata and contents when the source file changes, ensuring buffered responses stay in sync with the underlying files.

New Features:
- Support automatic refresh of buffered static file contents and metadata when the source file mtime or size changes.

Bug Fixes:
- Ensure ETag/MD5 and content for buffered static files are updated when the underlying file changes instead of serving stale responses.
- Clear cached gzip buffers when the source file changes so compressed responses are regenerated from current contents.

Tests:
- Add an integration test verifying buffered files are reloaded and ETags change when the source file is modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static cached file freshness checks to detect changes using both modification time and file size, including scenarios where content is already buffered, so updates and ETags refresh reliably.

* **Tests**
  * Added coverage for buffered + dynamic refresh behavior, verifying that cached buffered content updates after source changes and that the ETag reflects the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->